### PR TITLE
Decouple web3 from the provider

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+RPC_URL="test-url.com"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-export { VerifyingProvider } from './provider';
+import VerifyingProvider from './provider';
+export default VerifyingProvider
 export * from './server';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 import VerifyingProvider from './provider';
-export default VerifyingProvider
+export { VerifyingProvider }
 export * from './server';

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -1,0 +1,104 @@
+import http from 'http';
+import Web3 from "web3"
+import { MAX_SOCKET } from './constants';
+import { RequestMethodCallback, Method, AccountRequest, CodeRequest, Bytes32, GetProof, BlockNumber, Request, Response, RPCTx } from "./types"
+import { getEnv } from "./utils"
+import { bigIntToHex } from "@ethereumjs/util"
+import { Block } from 'web3-eth';
+import _ from 'lodash';
+
+export default class extends Web3 {
+	constructor(providerURL?: string) {
+		providerURL = providerURL || getEnv('RPC_URL')
+
+		const providerOpts = {
+			keepAlive: true,
+			agent: {
+				http: new http.Agent({ keepAlive: true, maxSockets: MAX_SOCKET }),
+			},
+		}
+
+		const provider = new Web3.providers.HttpProvider(providerURL, providerOpts)
+		super(provider)
+	}
+
+	public getBlock(hashOrNumber: BlockNumber, includeTx?: boolean): Promise<Block> {
+		return this.eth.getBlock(hashOrNumber, includeTx || true)
+	}
+
+	public async createAccessList(tx: RPCTx , blockNumber: bigint) {
+		const { accessList } = await this.eth.createAccessList(tx, bigIntToHex(blockNumber));
+		return accessList
+	}
+
+	public async sendRawTransaction(signedTx: string) {
+		const recipt = await this.eth.sendSignedTransaction(signedTx);
+		return (recipt as any).transactionHash;
+	}
+
+	public getProof(addressHex: string, storageSlots: Bytes32[], blockNumber: bigint): Promise<GetProof> {
+		//@ts-ignore
+		return this.eth.getProof(addressHex, storageSlots, bigintToHex(blockNumber))
+	}
+
+	public getProofRequest(request: AccountRequest, callback: RequestMethodCallback): Method {
+		//@ts-ignore
+		return this.eth.getProof.request(
+			request.addressHex,
+			request.storageSlots,
+			bigIntToHex(request.blockNumber),
+			callback,
+		)
+	}
+
+	public getCodeRequest(request: CodeRequest, callback: RequestMethodCallback): Method {
+		//@ts-ignore
+		return this.eth.getCode.request(
+			request.addressHex,
+			bigIntToHex(request.blockNumber),
+			callback
+		)
+	}
+
+	async fetchRequests(requests: Request[]) {
+		const batch = new this.BatchRequest();
+		const promises = requests.map(request => {
+			return new Promise<Response>((resolve, reject) => {
+				// Type error ignored due to https://github.com/ChainSafe/web3.js/issues/4655
+				const method = this.constructRequestMethod(
+				request,
+				(error: Error, data: Response) => {
+					if (error) reject(error);
+					resolve(data);
+				},
+				);
+				batch.add(method);
+			});
+		});
+
+		batch.execute();
+		return Promise.all(promises);
+	}
+
+	async fetchRequestsInBatches(
+		requests: Request[],
+		batchSize: number,
+	): Promise<Response[]> {
+		const results: Response[] = [];
+		const batchedRequests = _.chunk(requests, batchSize);
+
+		for (const requestBatch of batchedRequests) {
+			const res = await this.fetchRequests(requestBatch);
+			results.push(...res);
+		}
+		return results;
+	}
+
+	private constructRequestMethod(request: Request, callback: RequestMethodCallback): Method {
+		switch (request.type) {
+			case 'account': return this.getProofRequest(request, callback);
+			case 'code':    return this.getCodeRequest(request, callback);
+		}
+	}
+
+}

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -5,7 +5,7 @@ import { bigIntToHex } from "@ethereumjs/util"
 import { Block } from 'web3-eth';
 import { getEnv } from "./utils"
 import { MAX_SOCKET } from './constants';
-import { RequestMethodCallback, Method, AccountRequest, CodeRequest, Bytes32, GetProof, BlockNumber, Request, Response, RPCTx } from "./types"
+import { RequestMethodCallback, RequestMethods, Method, AccountRequest, CodeRequest, Bytes32, GetProof, BlockNumber, Request, Response, RPCTx } from "./types"
 
 export default class extends Web3 {
 	constructor(providerURL?: string) {
@@ -68,12 +68,16 @@ export default class extends Web3 {
 		return results;
 	}
 
-	private constructRequestMethod(request: Request, callback: RequestMethodCallback): Method {
-		switch (request.type) {
-			case 'account': return this.getProofRequest(request, callback);
-			case 'code':    return this.getCodeRequest(request, callback);
+	private constructRequestMethod(request: Request, cb: RequestMethodCallback): Method {
+		const methods: RequestMethods = {
+			account: this.getProofRequest,
+			code: this.getCodeRequest
 		}
+
+		const { type } = request
+		return methods[type](request, cb)
 	}
+
 
 	private getProofRequest({ addressHex, storageSlots, blockNumber, }: AccountRequest, callback: RequestMethodCallback): Method {
 		 //@ts-ignore

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import bodyParser from 'body-parser';
 import { JSONRPCServer, JSONRPCServerMiddleware } from 'json-rpc-2.0';
 import { RPCTx } from './types';
 import { INTERNAL_ERROR } from './constants';
-import { VerifyingProvider } from './provider';
+import VerifyingProvider from './provider';
 
 export function getApp(provider: VerifyingProvider) {
   const server = new JSONRPCServer();

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,9 @@ export type CodeResponse = string;
 export type Request = AccountRequest | CodeRequest;
 export type Response = AccountResponse | CodeResponse;
 
+type RequestFn = (request: Request, cb: RequestMethodCallback) => Method
+export type RequestMethods = Record<Request['type'], RequestFn>
+
 export type RequestMethodCallback = (error: Error, data: Response) => void;
 
 export type JSONRPCBlock = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,6 @@ import {
   isTruthy,
   setLengthLeft,
   toBuffer,
-  bigIntToHex,
   bufferToHex,
   intToHex,
 } from '@ethereumjs/util';
@@ -13,7 +12,22 @@ import {
   FeeMarketEIP1559TxData,
   TypedTransaction,
 } from '@ethereumjs/tx';
+import Web3 from 'web3';
 import { JSONRPCTx, JSONRPCBlock } from './types';
+
+export const numberToHex = Web3.utils.numberToHex
+export const keccak256 = Web3.utils.keccak256
+
+export const bigIntToHex = (n: string | bigint): string =>
+  '0x' + BigInt(n).toString(16);
+
+export function getEnv(name: string): string {
+  if (name in process.env) {
+    return String(process.env[name])
+  }
+
+  throw new Error(`Missing env variable: ${name}`)
+}
 
 // TODO: fix blockInfo type
 export function headerDataFromWeb3Response(blockInfo: any): HeaderData {


### PR DESCRIPTION
Working on the testing side of things, decoupling the web3 component will make mocking easier.